### PR TITLE
Docs: Fix example code links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,15 +103,15 @@ Check out the [**live demo**](http://slatejs.org) of all of the examples!
 
 To get a sense for how you might use Slate, check out a few of the examples:
 
-- [**Plain text**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/plaintext.js) — showing the most basic case: a glorified `<textarea>`.
-- [**Rich text**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/richtext.js) — showing the features you'd expect from a basic editor.
-- [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/markdown-preview.js) — showing how to add key handlers for Markdown-like shortcuts.
-- [**Links**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/links.js) — showing how wrap text in inline nodes with associated data.
-- [**Images**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/images.js) — showing how to use void (text-less) nodes to add images.
-- [**Hovering toolbar**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/hovering-toolbar.js) — showing how a hovering toolbar can be implemented.
-- [**Tables**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/tables.js) — showing how to nest blocks to render more advanced components.
-- [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/paste-html.js) — showing how to use an HTML serializer to handle pasted HTML.
-- [**Mentions**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/mentions.js) — showing how to use inline void nodes for simple @-mentions.
+- [**Plain text**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/plaintext.tsx) — showing the most basic case: a glorified `<textarea>`.
+- [**Rich text**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/richtext.tsx) — showing the features you'd expect from a basic editor.
+- [**Markdown preview**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/markdown-preview.tsx) — showing how to add key handlers for Markdown-like shortcuts.
+- [**Links**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/links.tsx) — showing how wrap text in inline nodes with associated data.
+- [**Images**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/images.tsx) — showing how to use void (text-less) nodes to add images.
+- [**Hovering toolbar**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/hovering-toolbar.tsx) — showing how a hovering toolbar can be implemented.
+- [**Tables**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/tables.tsx) — showing how to nest blocks to render more advanced components.
+- [**Paste HTML**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/paste-html.tsx) — showing how to use an HTML serializer to handle pasted HTML.
+- [**Mentions**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/mentions.tsx) — showing how to use inline void nodes for simple @-mentions.
 - [**See all the examples...**](https://github.com/ianstormtaylor/slate/tree/master/site/examples/)
 
 If you have an idea for an example that shows a common use case, pull request it!


### PR DESCRIPTION
Replaced old .js links with current .tsx format

#### Is this adding or improving a _feature_ or fixing a _bug_?

<!--
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!--
Please include at least one of the following:

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!--
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
